### PR TITLE
Bugfix for slack notifications

### DIFF
--- a/templates/slack.json
+++ b/templates/slack.json
@@ -1,7 +1,7 @@
 {
   "text": " ",
   "username": "Image Factory",
-  "channel": "{{ channel }}",
+  "channel": "{{ notification.channel }}",
   "attachments": [{
     "text": "A *{{ ctx.env }}* build for *{{ ctx.repo }}* has failed!\nFor more details, view the <{{ ctx.baseUrl }}/job/{{ ctx.id }}/log|logs>.",
     "color": "danger",


### PR DESCRIPTION
### Overview

The `channel` property in `templates/slack.json` was being referenced incorrectly. It should have been `notification.channel`. Because the channel was then an empty string, it defaulted back to the channel given by the integration url.
